### PR TITLE
WIP refactor: :+1: 全体をexportするようにした

### DIFF
--- a/czfe.config.js
+++ b/czfe.config.js
@@ -1,53 +1,53 @@
-const questions = [
-  // @todo 選択肢は上から読ませるようにするので、sort用にNumber降ることはしない
-  {
-    // @see https://github.com/SBoudrias/Inquirer.js/
-    name: 'prefix',
-    message: 'コミットする変更タイプを選択：',
-    // 'list' 'input' 'number' 'confirm' 'rawlist' 'expand' 'checkbox' 'password' 'editor'
-    type: 'list',
-    prefix: '👉',
-    choices: [
-      {
-        name: 'feat:',
-        description: '新機能',
-      },
-      {
-        name: 'fix:',
-        description: 'バグ修正',
-      },
-    ],
-  },
-  {
-    name: 'scope',
-    message:
-      '変更内容のスコープ(例:コンポーネントやファイル名):（enterでスキップ）\n',
-    type: 'input',
-    prefix: '👉',
-  },
-  {
-    name: 'emoji',
-    message: 'コミット内容に合うemojiを選択:',
-    type: 'list',
-    prefix: '👉',
-    choices: [
-      {
-        name: ':bug:',
-        description: '🐛 バグの修正',
-      },
-      {
-        name: ':tada:',
-        description: '🎉 新機能の実装',
-      },
-    ],
-  },
-  {
-    name: 'body',
-    message:
-      '変更内容のスコープ(例:コンポーネントやファイル名):（enterでスキップ）\n',
-    type: 'input',
-    prefix: '👉',
-  },
-];
-
-module.exports = { questions };
+module.exports = {
+  questions: [
+    // @todo 選択肢は上から読ませるようにするので、sort用にNumber降ることはしない
+    {
+      // @see https://github.com/SBoudrias/Inquirer.js/
+      name: 'prefix',
+      message: 'コミットする変更タイプを選択：',
+      // 'list' 'input' 'number' 'confirm' 'rawlist' 'expand' 'checkbox' 'password' 'editor'
+      type: 'list',
+      prefix: '👉',
+      choices: [
+        {
+          name: 'feat:',
+          description: '新機能',
+        },
+        {
+          name: 'fix:',
+          description: 'バグ修正',
+        },
+      ],
+    },
+    {
+      name: 'scope',
+      message:
+        '変更内容のスコープ(例:コンポーネントやファイル名):（enterでスキップ）\n',
+      type: 'input',
+      prefix: '👉',
+    },
+    {
+      name: 'emoji',
+      message: 'コミット内容に合うemojiを選択:',
+      type: 'list',
+      prefix: '👉',
+      choices: [
+        {
+          name: ':bug:',
+          description: '🐛 バグの修正',
+        },
+        {
+          name: ':tada:',
+          description: '🎉 新機能の実装',
+        },
+      ],
+    },
+    {
+      name: 'body',
+      message:
+        '変更内容のスコープ(例:コンポーネントやファイル名):（enterでスキップ）\n',
+      type: 'input',
+      prefix: '👉',
+    },
+  ],
+};

--- a/lib/common.js
+++ b/lib/common.js
@@ -8,9 +8,13 @@ const rightPad = require('right-pad');
 
 const configFileName = 'czfe';
 const explorer = cosmiconfig(configFileName);
+/**
+ * @returns filePath 直近のczrc.config.jsのディレクトリ名
+ * @returns config 直近のczrc.config.js内の値
+ */
 
 async function initialize() {
-  const data = await explorer.search(); // not exist file or contents
+  const data = await explorer.search(); // Error not exist file or contents
 
   if (!data || !data.config) {
     throw new Error(`${configFileName}.config.js file not found`);
@@ -25,6 +29,12 @@ async function initialize() {
     config
   };
 }
+/**
+ * 配列の要素で一番長いstringの数を数える
+ * @param {*} array
+ * @returns number 一番長い数 + 1
+ */
+
 
 function getMaxLength(array) {
   // longestにわたす配列作成
@@ -33,6 +43,11 @@ function getMaxLength(array) {
   }) => name);
   return longest(choiceNameArray).length + 1;
 }
+/**
+ * commit configの設定
+ * @param {*} question czrc.config.jsのquestionsのアイテム
+ */
+
 
 function createCommitConfig(question) {
   if (!question.choices) return question; // choicesで一番長いnameの文字数を計算 + 余白

--- a/src/common.js
+++ b/src/common.js
@@ -5,10 +5,14 @@ const rightPad = require('right-pad');
 const configFileName = 'czfe';
 const explorer = cosmiconfig(configFileName);
 
+/**
+ * @returns filePath 直近のczrc.config.jsのディレクトリ名
+ * @returns config 直近のczrc.config.js内の値
+ */
 async function initialize() {
   const data = await explorer.search();
 
-  // not exist file or contents
+  // Error not exist file or contents
   if (!data || !data.config) {
     throw new Error(`${configFileName}.config.js file not found`);
   }
@@ -20,12 +24,21 @@ async function initialize() {
   };
 }
 
+/**
+ * 配列の要素で一番長いstringの数を数える
+ * @param {*} array
+ * @returns number 一番長い数 + 1
+ */
 function getMaxLength(array) {
   // longestにわたす配列作成
   const choiceNameArray = array.map(({ name }) => name);
   return longest(choiceNameArray).length + 1;
 }
 
+/**
+ * commit configの設定
+ * @param {*} question czrc.config.jsのquestionsのアイテム
+ */
 function createCommitConfig(question) {
   if (!question.choices) return question;
   // choicesで一番長いnameの文字数を計算 + 余白


### PR DESCRIPTION
ユーザーが設定しやすいように変更

closes #49

# 確認事項
- [x] マージ先はbetaか
- [ ] cliのテストは成功しているか
- [x] コミットコメントは適切なものか
- [x] 何をしたか、なぜしたかを書いたか

# 何をしたか
- czrc.config.js全体を`module.exports`で囲った。

# なぜしたか
- ユーザーが設定しやすいように

# TODO
- [ ] `format`キーを追加する